### PR TITLE
Added Hardware Reset to .Net wrapper

### DIFF
--- a/wrappers/csharp/Intel.RealSense/Devices/Device.cs
+++ b/wrappers/csharp/Intel.RealSense/Devices/Device.cs
@@ -66,6 +66,12 @@ namespace Intel.RealSense
                 return QuerySensors();
             }
         }
+		
+		public void HardwareReset()
+		{
+			object error;
+			NativeMethods.rs2_hardware_reset(m_instance, out error);
+		}
 
         #region IDisposable Support
         private bool disposedValue = false; // To detect redundant calls


### PR DESCRIPTION
NativeMethods.cs declares rs2_hardware_reset but there was no corresponding call from managed code.